### PR TITLE
Add the ability to pass an instance of a css preprocessor (sass, less, stylus) into loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # rollup-plugin-postcss
 
-[![NPM version](https://img.shields.io/npm/v/rollup-plugin-postcss.svg?style=flat)](https://npmjs.com/package/rollup-plugin-postcss) [![NPM downloads](https://img.shields.io/npm/dm/rollup-plugin-postcss.svg?style=flat)](https://npmjs.com/package/rollup-plugin-postcss) [![Build Status](https://img.shields.io/circleci/project/egoist/rollup-plugin-postcss/master.svg?style=flat)](https://circleci.com/gh/egoist/rollup-plugin-postcss) [![codecov](https://codecov.io/gh/egoist/rollup-plugin-postcss/branch/master/graph/badge.svg)](https://codecov.io/gh/egoist/rollup-plugin-postcss)
- [![donate](https://img.shields.io/badge/$-donate-ff69b4.svg?maxAge=2592000&style=flat)](https://github.com/egoist/donate)
+[![Build Status](https://img.shields.io/circleci/build/gh/PebblePad/rollup-plugin-postcss/master.svg?style=flat)](https://circleci.com/gh/egoist/rollup-plugin-postcss) [![codecov](https://codecov.io/gh/PebblePad/rollup-plugin-postcss/branch/master/graph/badge.svg)](https://codecov.io/gh/egoist/rollup-plugin-postcss)
 
 <img align="right" width="95" height="95"
      title="Philosopher’s stone, logo of PostCSS"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "8"
+  nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:lts
     branches:
       ignore:
         - gh-pages # list of branches to ignore

--- a/src/less-loader.js
+++ b/src/less-loader.js
@@ -6,10 +6,15 @@ export default {
   name: 'less',
   test: /\.less$/,
   async process({ code }) {
-    const less = importCwd('less')
+    const { lessInstance, ...options } = this.options
+    const less = lessInstance || importCwd('less')
+
+    if (!less) {
+      throw new Error(`You need to install less or provide a less compiler in order to process less files`)
+    }
 
     let { css, map, imports } = await pify(less.render.bind(less))(code, {
-      ...this.options,
+      ...options,
       sourceMap: this.sourceMap && {},
       filename: this.id
     })

--- a/src/sass-loader.js
+++ b/src/sass-loader.js
@@ -23,14 +23,15 @@ export default {
   test: /\.s[ac]ss$/,
   process({ code }) {
     return new Promise((resolve, reject) => {
-      const sass = importCwd.silent('node-sass') || importCwd.silent('sass')
+      const { sassInstance, ...options } = this.options
+      const sass = sassInstance || importCwd.silent('node-sass') || importCwd.silent('sass')
       if (!sass) {
-        throw new Error(`You need to install either node-sass or sass in order to process Sass files`)
+        throw new Error(`You need to install either node-sass, sass or provide a compiler in order to process Sass files`)
       }
       const render = pify(sass.render.bind(sass))
       return workQueue.add(() =>
         render({
-          ...this.options,
+          ...options,
           file: this.id,
           data: code,
           indentedSyntax: /\.sass$/.test(this.id),

--- a/src/stylus-loader.js
+++ b/src/stylus-loader.js
@@ -5,10 +5,15 @@ export default {
   name: 'stylus',
   test: /\.(styl|stylus)$/,
   async process({ code }) {
-    const stylus = importCwd('stylus')
+    const { stylusInstance, ...options } = this.options
+    const stylus = stylusInstance || importCwd('stylus')
+
+    if (!stylus) {
+      throw new Error(`You need to install stylus or provide a compiler in order to process stylus files`)
+    }
 
     const style = stylus(code, {
-      ...this.options,
+      ...options,
       filename: this.id,
       sourcemap: this.sourceMap && {}
     })

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -368,6 +368,111 @@ console.log(css, css$1);
 "
 `;
 
+exports[`less default: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n\\";
+styleInject(css);
+"
+`;
+
+exports[`less provided instance: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n\\";
+styleInject(css);
+"
+`;
+
+exports[`less sourcemap: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QvZml4dHVyZXMvbGVzcy9mb28ubGVzcyIsImZvby5sZXNzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0UsVUFBQTtFQUNBLHNCQUFBO0FDQ0YiLCJmaWxlIjoiZm9vLmxlc3MifQ== */\\";
+styleInject(css);
+"
+`;
+
 exports[`minimize extract: css code 1`] = `".bar,body{color:red}body{background:red}#sidebar{width:30%;background-color:#faa}#header{color:#6c94be}.pcss{color:red}"`;
 
 exports[`minimize extract: js code 1`] = `
@@ -804,6 +909,41 @@ console.log(style);
 "
 `;
 
+exports[`sass provided instance: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa; }\\\\n\\";
+styleInject(css);
+"
+`;
+
 exports[`sass sourcemap: js code 1`] = `
 "'use strict';
 
@@ -940,5 +1080,110 @@ var css$5 = \\".pcss {\\\\n  color: red;\\\\n}\\\\n\\\\n/*# sourceMappingURL=dat
 styleInject(css$5);
 
 console.log(css, css$1);
+"
+`;
+
+exports[`stylus default: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n\\";
+styleInject(css);
+"
+`;
+
+exports[`stylus provided instance: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n\\";
+styleInject(css);
+"
+`;
+
+exports[`stylus sourcemap: js code 1`] = `
+"'use strict';
+
+function styleInject(css, ref) {
+  if ( ref === void 0 ) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (!css || typeof document === 'undefined') { return; }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+var css = \\"#sidebar {\\\\n  width: 30%;\\\\n  background-color: #faa;\\\\n}\\\\n/*# sourceMappingURL=test/fixtures/stylus/foo.css.map */\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QvZml4dHVyZXMvc3R5bHVzL2Zvby5zdHlsdXMiLCJmb28uc3R5bHVzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0UsVUFBTztFQUNQLHNCQUFrQjtBQ0NwQjtBQUNBLHVEQUF1RCIsImZpbGUiOiJmb28uc3R5bHVzIn0= */\\";
+styleInject(css);
 "
 `;

--- a/test/fixtures/less/foo.less
+++ b/test/fixtures/less/foo.less
@@ -1,0 +1,4 @@
+#sidebar {
+  width: 30%;
+  background-color: #faa;
+}

--- a/test/fixtures/less/index.js
+++ b/test/fixtures/less/index.js
@@ -1,0 +1,1 @@
+import './foo.less'

--- a/test/fixtures/stylus/foo.stylus
+++ b/test/fixtures/stylus/foo.stylus
@@ -1,0 +1,4 @@
+#sidebar {
+  width: 30%;
+  background-color: #faa;
+}

--- a/test/fixtures/stylus/index.js
+++ b/test/fixtures/stylus/index.js
@@ -1,0 +1,1 @@
+import './foo.stylus'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,9 @@
 import path from 'path'
 import fs from 'fs-extra'
 import { rollup } from 'rollup'
+import nodeSass from 'node-sass'
+import less from 'less'
+import stylus from 'stylus'
 import postcss from '../src'
 
 process.env.ROLLUP_POSTCSS_TEST = true
@@ -308,6 +311,13 @@ snapshotMany('sass', [
     }
   },
   {
+    title: 'provided instance',
+    input: 'sass/index.js',
+    options: {
+      use: [['sass', { sassInstance: nodeSass }]]
+    }
+  },
+  {
     title: 'modules',
     input: 'sass-modules/index.js',
     options: {
@@ -317,6 +327,48 @@ snapshotMany('sass', [
   {
     title: 'import',
     input: 'sass-import/index.js'
+  }
+])
+
+snapshotMany('less', [
+  {
+    title: 'default',
+    input: 'less/index.js'
+  },
+  {
+    title: 'sourcemap',
+    input: 'less/index.js',
+    options: {
+      sourceMap: true
+    }
+  },
+  {
+    title: 'provided instance',
+    input: 'less/index.js',
+    options: {
+      use: [['less', { lessInstance: less }]]
+    }
+  }
+])
+
+snapshotMany('stylus', [
+  {
+    title: 'default',
+    input: 'stylus/index.js'
+  },
+  {
+    title: 'sourcemap',
+    input: 'stylus/index.js',
+    options: {
+      sourceMap: true
+    }
+  },
+  {
+    title: 'provided instance',
+    input: 'stylus/index.js',
+    options: {
+      use: [['stylus', { stylusInstance: stylus }]]
+    }
   }
 ])
 


### PR DESCRIPTION
Added the ability to pass in a preprocessor instance to a loader, along with unit tests for the new option. Saw that there were no existing tests for LESS and Stylus, so took the opportunity to add some basic ones for them as well.